### PR TITLE
fix: correctly parse quality values of 1 as short floating points

### DIFF
--- a/src/lookup-list.ts
+++ b/src/lookup-list.ts
@@ -170,7 +170,7 @@ export default class LookupList {
      * - A quality value equivalent to "0", as per RFC 2616 (section 3.9), should be considered as "not acceptable".
      */
     const directiveMatch = directiveString.match(
-      /^((?<matchedLanguageCode>([a-z]{2}))(-(?<matchedCountryCode>[a-z]{2}))?)(;q=(?<matchedQuality>1|0.(\d*[1-9]\d*){1,3}))?$/i
+      /^((?<matchedLanguageCode>([a-z]{2}))(-(?<matchedCountryCode>[a-z]{2}))?)(;q=(?<matchedQuality>(1(\.0{0,3})?)|(0(\.\d{0,3})?)))?$/i
     )
 
     if (!directiveMatch?.groups) return undefined // No regular expression match.

--- a/tests/resolve-accept-language.test.ts
+++ b/tests/resolve-accept-language.test.ts
@@ -285,6 +285,10 @@ describe("`resolveAcceptLanguage`'s lookup mechanism", () => {
         'en-US'
       )
     ).toEqual('en-CA')
+
+    expect(resolveAcceptLanguage('fr-CA;q=1.0,en-US;q=0.9', ['en-US', 'fr-CA'], 'en-US')).toEqual(
+      'fr-CA'
+    )
   })
 
   it('returns the correct locale based on language code quality', () => {


### PR DESCRIPTION
According to RFC 2616 the qvalue is defined as
```
qvalue         = ( "0" [ "." 0*3DIGIT ] )
               | ( "1" [ "." 0*3("0") ] )
```
therefore allowing qvalues like `1.0`, `1.00` and `1.000`, which was currently not the case and the library would only allow `1`.

I've added a test for this case and adapted the regex to allow the 1 value as a short floating point.

Furthermore i saw that the dot was not escaped and thus would allow qvalues like `0a99`.
Also adapted the regex for the decimal digits to be more aligned to the RFC spec.